### PR TITLE
Added the Back-top-button with smooth scroll and animation

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "react-hot-toast";
+import BackToTopButton from '../components/ui/BackToTopButton';
 
 const geistSans = Geist({
     variable: "--font-geist-sans",
@@ -77,6 +78,7 @@ export default function RootLayout({
                 className={`${geistSans.variable} ${geistMono.variable} antialiased`}
             >
                 {children}
+                <BackToTopButton />
                 <Toaster
                     position="top-center"
                     containerStyle={{

--- a/apps/web/components/pages/About.tsx
+++ b/apps/web/components/pages/About.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import { LoginModal } from "../modals/Login";
 import { SignupModal } from "../modals/Signup";
 
+
 const features = [
     {
         text: "Important questions, Important Topics & reference books",

--- a/apps/web/components/pages/About.tsx
+++ b/apps/web/components/pages/About.tsx
@@ -20,7 +20,6 @@ import { useState } from "react";
 import { LoginModal } from "../modals/Login";
 import { SignupModal } from "../modals/Signup";
 
-
 const features = [
     {
         text: "Important questions, Important Topics & reference books",

--- a/apps/web/components/ui/BackToTopButton.tsx
+++ b/apps/web/components/ui/BackToTopButton.tsx
@@ -30,7 +30,7 @@ const BackToTopButton: React.FC = () => {
         width: 60,
         height: 60,
         borderRadius: '50%',
-        background: 'linear-gradient(135deg, #4f46e5, #7c3aed)',
+        background: 'black',
         color: '#fff',
         fontSize: 26,
         fontWeight: 'bold',

--- a/apps/web/components/ui/BackToTopButton.tsx
+++ b/apps/web/components/ui/BackToTopButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+const BackToTopButton: React.FC = () => {
+  const [visible, setVisible] = useState<boolean>(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.pageYOffset > 300);
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      style={{
+        position: 'fixed',
+        bottom: 30,
+        right: 30,
+        width: 60,
+        height: 60,
+        borderRadius: '50%',
+        background: 'linear-gradient(135deg, #4f46e5, #7c3aed)',
+        color: '#fff',
+        fontSize: 26,
+        fontWeight: 'bold',
+        letterSpacing: '1px',
+        border: 'none',
+        cursor: 'pointer',
+        boxShadow: '0 0 15px rgba(124, 58, 237, 0.6), 0 0 30px rgba(79, 70, 229, 0.3)',
+        zIndex: 1000,
+        transition: 'all 0.3s ease',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        animation: 'floatUpDown 2s ease-in-out infinite',
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(20px)',
+      }}
+      aria-label="Back to top"
+      onMouseOver={(e) => {
+        e.currentTarget.style.transform = 'scale(1.1)';
+      }}
+      onMouseOut={(e) => {
+        e.currentTarget.style.transform = 'scale(1)';
+      }}
+    >
+      ↑
+    </button>
+  );
+};
+
+export default BackToTopButton;


### PR DESCRIPTION
Related issue: #13 
**Feature:** Back to Top Button

**Description**
This PR introduces a responsive and visually appealing "Back to Top" button to improve the user experience during long scroll sessions across the Prepnerdz site.

**What I Added**
- A new reusable component: `BackToTopButton.tsx`
- Button appears after scrolling down 300px
- Smooth scroll behavior on click
- Stylish design with gradient background, glow effect, and subtle animations

**Screenshots**

<img width="1919" height="1014" alt="image" src="https://github.com/user-attachments/assets/3a283f34-ee4f-475f-a95d-c0fa1e96f468" />

couldn't add screen recordings since the file is large  

**How to Test**
1. Scroll down the page (300px+)
2. Observe the appearance of the "Back to Top" button at the bottom-right
3. Click the button → smooth scroll to top

Closes: #13 
