### PR TITLE
fix: correct Back to Login button route on Forgot Password page

### DIFF
--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -11,6 +11,9 @@ import InputBulged from "@/components/ui/inputs/InputBulged";
 import { Email } from "@/icons/Email";
 import { OtpDot } from "@/icons/OtpDot";
 import { Key } from "@/icons/Key";
+import { LoginModal } from "@/components/modals/Login";
+import { SignupModal } from "@/components/modals/Signup";
+
 
 export default function ForgotPassword() {
     const router = useRouter();
@@ -21,6 +24,9 @@ export default function ForgotPassword() {
     const [step, setStep] = useState(1); // 1: email input, 2: OTP and new password
     const [loading, setLoading] = useState(false);
     const [notification, setNotification] = useState<{ message: string, type: 'success' | 'error' } | null>(null);
+    const [isLoginOpen, setIsLoginOpen] = useState(false);
+    const [isSignupOpen, setIsSignupOpen] = useState(false);
+    
 
     const handleSendOtp = async () => {
         if (!email) {
@@ -84,6 +90,27 @@ export default function ForgotPassword() {
 
     return (
         <div className="relative min-h-screen bg-mainBgColor overflow-hidden">
+      
+             <div>
+                    <LoginModal
+                        open={isLoginOpen}
+                        onClose={() => setIsLoginOpen(false)}
+                        onSwitchToSignup={() => {
+                            setIsLoginOpen(false);
+                            setIsSignupOpen(true);
+                        }}
+                    />
+
+                    <SignupModal
+                        open={isSignupOpen}
+                        onClose={() => setIsSignupOpen(false)}
+                        onSwitchToLogin={() => {
+                            setIsSignupOpen(false);
+                            setIsLoginOpen(true);
+                        }}
+                    />
+                
+        </div>
             {/* Notification Popup */}
             {notification && (
                 <motion.div
@@ -159,7 +186,10 @@ export default function ForgotPassword() {
                                         text="Back to Login"
                                         colorVariant="black_yellow"
                                         sizeVariant="medium"
-                                        onClick={() => router.push('/signin')}
+                                        onClick={() => { 
+                                            setIsLoginOpen(true)
+                                            
+                                        }}
                                     >
                                     </Button>
                                 </div>

--- a/apps/web/components/modals/Login.tsx
+++ b/apps/web/components/modals/Login.tsx
@@ -207,7 +207,7 @@ export const LoginModal = ({ open, onClose, onSwitchToSignup }: LoginProps) => {
 
                             {/* Forgot Password */}
                             <div className="flex justify-center transition-all text-base md:text-xl duration-500 hover:text-blue-600 font-bold mt-2 md:mt-0">
-                                <Link href={"/forgot-password"}>
+                                <Link href={"/forgot-password"} onClick={()=>{ onClose()}}>
                                     Forgot Password?
                                 </Link>
                             </div>


### PR DESCRIPTION
Issue:
Previously, clicking the "Back to Login" button on the Forgot Password page redirected users to /signin, a route that does not exist, resulting in a 404 error.

IssueNo :- #56 

Fix Implemented:
Instead of redirecting to a non-existent page, I updated the button's functionality to directly open the LoginModal, providing a seamless user experience without any page navigation.

Testing:
- Verified that clicking Back to Login opens the login modal as expected.
- No 404 or unwanted navigation occurs.



https://github.com/user-attachments/assets/ad9fa8b0-f575-4d2b-8097-e4e6abe67ad7



