### PR TITLE
The clock widget dynamically adjust its theme based on the time of day

### DIFF
--- a/apps/web/components/ui/cards/DateTime.tsx
+++ b/apps/web/components/ui/cards/DateTime.tsx
@@ -1,71 +1,81 @@
-import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+"use client";
+
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
 
 const DateTimeCard = () => {
-    const [currentTime, setCurrentTime] = useState(new Date());
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const [isDayTime, setIsDayTime] = useState(true);
 
-    useEffect(() => {
-        const timer = setInterval(() => {
-            setCurrentTime(new Date());
-        }, 1000);
-
-        return () => {
-            clearInterval(timer);
-        };
-    }, []);
-
-    const formatTime = (date: Date) => {
-        let hours = date.getHours();
-        const minutes = date.getMinutes().toString().padStart(2, '0');
-        // const ampm = hours >= 12 ? 'PM' : 'AM';
-        hours = hours % 12;
-        hours = hours ? hours : 12; // the hour '0' should be '12'
-
-        // console.log(ampm);
-
-        return `${hours}:${minutes}`;
+  useEffect(() => {
+    const updateTime = () => {
+      const now = new Date();
+      setCurrentTime(now);
+      const hour = now.getHours();
+      setIsDayTime(hour >= 6 && hour < 19); // Daytime: 6 AM to 6:59 PM
     };
 
+    updateTime();
+    const timer = setInterval(updateTime, 1000);
+    return () => clearInterval(timer);
+  }, []);
 
-    const formatDate = (date: Date) => {
-        const options: Intl.DateTimeFormatOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-        return date.toLocaleDateString('en-US', options);
+  const formatTime = (date: Date) => {
+    let hours = date.getHours();
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    hours = hours % 12 || 12;
+    return `${hours}:${minutes}`;
+  };
+
+  const formatDate = (date: Date) => {
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     };
+    return date.toLocaleDateString("en-US", options);
+  };
 
-    return (
-        <StyledWrapper>
-            <div className="card">
-                <p className="time-text">
-                    <span>{formatTime(currentTime)}</span>
-                    <span className="time-sub-text">{currentTime.getHours() >= 12 ? 'PM' : 'AM'}</span>
-                </p>
-                <p className="day-text">{formatDate(currentTime)}</p>
-                <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 16 16" strokeWidth={0} fill="currentColor" stroke="currentColor" className="moon"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z" /><path d="M10.794 3.148a.217.217 0 0 1 .412 0l.387 1.162c.173.518.579.924 1.097 1.097l1.162.387a.217.217 0 0 1 0 .412l-1.162.387a1.734 1.734 0 0 0-1.097 1.097l-.387 1.162a.217.217 0 0 1-.412 0l-.387-1.162A1.734 1.734 0 0 0 9.31 6.593l-1.162-.387a.217.217 0 0 1 0-.412l1.162-.387a1.734 1.734 0 0 0 1.097-1.097l.387-1.162zM13.863.099a.145.145 0 0 1 .274 0l.258.774c.115.346.386.617.732.732l.774.258a.145.145 0 0 1 0 .274l-.774.258a1.156 1.156 0 0 0-.732.732l-.258.774a.145.145 0 0 1-.274 0l-.258-.774a1.156 1.156 0 0 0-.732-.732l-.774-.258a.145.145 0 0 1 0-.274l.774-.258c.346-.115.617-.386.732-.732L13.863.1z" /></svg>
-            </div>
-        </StyledWrapper>
-    );
-}
+  return (
+    <StyledWrapper isDay={isDayTime}>
+      <div className="card">
+        <p className="time-text">
+          <span>{formatTime(currentTime)}</span>
+          <span className="time-sub-text">
+            {currentTime.getHours() >= 12 ? "PM" : "AM"}
+          </span>
+        </p>
+        <p className="day-text">{formatDate(currentTime)}</p>
+        <div className="icon">
+          {isDayTime ? <span className="text-4xl">☀️</span> : <span className="text-4xl">🌙</span>}
+        </div>
+      </div>
+    </StyledWrapper>
+  );
+};
 
-const StyledWrapper = styled.div`
+const StyledWrapper = styled.div<{ isDay: boolean }>`
   .card {
-    width: 250px;
-    height: 120px; /* Changed from 150px to make it shorter */
-    background: rgb(17, 4, 134);
+    width: 255px;
+    height: 120px;
     border-radius: 15px;
-    /* Shadow removed from here */
     display: flex;
-    color: white;
     justify-content: center;
     position: relative;
     flex-direction: column;
-    background: linear-gradient(to right, rgb(20, 30, 48), rgb(36, 59, 85));
     cursor: pointer;
     transition: all 0.3s ease-in-out;
     overflow: hidden;
-  }
+    padding: 0 1rem;
 
-  .card:hover {
-    /* Shadow removed from here */
+    background: ${({ isDay }) =>
+      isDay
+    ? "linear-gradient(to right, #00b4d8, #caf0f8)"
+    : "linear-gradient(to right, rgb(20, 30, 48), rgb(36, 59, 85))" 
+   };
+
+    color: ${({ isDay }) => (isDay ? "#000" : "#fff")};
   }
 
   .time-text {
@@ -79,6 +89,7 @@ const StyledWrapper = styled.div`
   .time-sub-text {
     font-size: 15px;
     margin-left: 5px;
+    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
   }
 
   .day-text {
@@ -89,16 +100,17 @@ const StyledWrapper = styled.div`
     font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
   }
 
-  .moon {
-    font-size: 20px;
+  .icon {
     position: absolute;
     right: 15px;
     top: 15px;
+    font-size: 24px;
     transition: all 0.3s ease-in-out;
   }
 
-  .card:hover > .moon {
-    font-size: 23px;
-  }`;
+  .card:hover .icon {
+    font-size: 27px;
+  }
+`;
 
 export default DateTimeCard;


### PR DESCRIPTION
PR Description:
This PR enhances the DateTimeCard component by introducing dynamic day/night theme switching based on the current time.

Screenshots:

Day : 
<img width="327" height="275" alt="Screenshot 2025-08-06 194109" src="https://github.com/user-attachments/assets/d7dff1e2-a271-4f52-9735-412f0d6bab1e" />

Night : 
<img width="324" height="285" alt="Screenshot 2025-08-06 194154" src="https://github.com/user-attachments/assets/256b404d-f42c-4a3d-a4f7-ca8a3d4bdb17" />

Fixes #103 

Hello @Shubhashish-Chakraborty ,
Plz checkout this PR, I am happy to contribute as a part of GSSoC'25

